### PR TITLE
SEM-37 / SEM-39 Events page

### DIFF
--- a/apps/back/prisma/migrations/20240911225021_fix_events_dates/migration.sql
+++ b/apps/back/prisma/migrations/20240911225021_fix_events_dates/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `date` on the `Event` table. All the data in the column will be lost.
+  - Added the required column `end` to the `Event` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `start` to the `Event` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Credentials" DROP CONSTRAINT "Credentials_employeeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Encounter" DROP CONSTRAINT "Encounter_customerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Event" DROP CONSTRAINT "Event_employeeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Event" DROP CONSTRAINT "Event_locationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Payment" DROP CONSTRAINT "Payment_customerId_fkey";
+
+-- AlterTable
+ALTER TABLE "Event" DROP COLUMN "date",
+ADD COLUMN     "end" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "start" TIMESTAMP(3) NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Credentials" ADD CONSTRAINT "Credentials_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "Employee"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Event" ADD CONSTRAINT "Event_locationId_fkey" FOREIGN KEY ("locationId") REFERENCES "Location"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Event" ADD CONSTRAINT "Event_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "Employee"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Encounter" ADD CONSTRAINT "Encounter_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/back/prisma/schema.prisma
+++ b/apps/back/prisma/schema.prisma
@@ -127,7 +127,8 @@ model Event {
   id              Int        @id @default(autoincrement())
   legacyId        Int?       @unique
   title           String
-  date            DateTime
+  start           DateTime
+  end             DateTime
   maxParticipants Int
   location        Location   @relation(fields: [locationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   locationId      Int

--- a/apps/back/prisma/seed.ts
+++ b/apps/back/prisma/seed.ts
@@ -130,11 +130,15 @@ async function main(): Promise<void> {
     const biggestLegacyId = await prisma.event.findFirst({
       orderBy: { legacyId: 'desc' },
     });
+    const start = faker.date.recent({ days: 60 });
+    const end = new Date(start);
+    end.setHours(start.getHours() + faker.number.int({ min: 1, max: 5 }));
     await prisma.event.create({
       data: {
         legacyId: biggestLegacyId?.legacyId ? biggestLegacyId.legacyId + 1 : 1,
         title: faker.lorem.words(3),
-        date: faker.date.recent({ days: 60 }),
+        start,
+        end,
         maxParticipants: faker.number.int({ min: 1, max: 10 }),
         location: {
           create: {

--- a/apps/back/src/app/app.module.ts
+++ b/apps/back/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { LegacyApiModule } from '../providers/legacy-api/legacy-api.module';
 import { AuthGuard } from '../modules/auth/guards/jwt-auth.guard';
 import { StatisticsModule } from '../modules/statistics/statistics.module';
 import { ImagesModule } from '../modules/images/images.module';
+import { EventsModule } from '../modules/events/events.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { ImagesModule } from '../modules/images/images.module';
     CustomersModule,
     StatisticsModule,
     ImagesModule,
+    EventsModule,
   ],
   controllers: [],
   providers: [

--- a/apps/back/src/modules/customers/customers.controller.ts
+++ b/apps/back/src/modules/customers/customers.controller.ts
@@ -122,8 +122,9 @@ export class CustomersController {
     const customerCount =
       await this.customersService.getCustomersCount(filters);
 
+    const pageIndex = Math.floor(customerCount / size);
     const isLast = customerCount <= page * size + size;
-    const startIndex = isLast ? Math.max(0, customerCount - size) : page * size;
+    const startIndex = pageIndex * size;
     const items = (
       await this.customersService.getCustomers(filters, size, startIndex)
     ).map((customer: Customer): Customer => {
@@ -140,7 +141,7 @@ export class CustomersController {
     });
 
     return {
-      index: page,
+      index: pageIndex,
       size: items.length,
       isLast,
       items,
@@ -264,8 +265,9 @@ export class CustomersController {
     const paymentCount =
       await this.customersService.getCustomerPaymentsCount(id);
 
+    const pageIndex = Math.floor(paymentCount / size);
     const isLast = paymentCount < page * size + size;
-    const startIndex = isLast ? Math.max(0, paymentCount - size) : page * size;
+    const startIndex = pageIndex * size;
     const items = await this.customersService.getCustomerPayments(
       id,
       size,
@@ -273,7 +275,7 @@ export class CustomersController {
     );
 
     return {
-      index: page,
+      index: pageIndex,
       size: items.length,
       isLast,
       items,
@@ -544,8 +546,9 @@ export class CustomersController {
     const clothesCount =
       await this.customersService.getCustomerClothesCount(id);
 
+    const pageIndex = Math.floor(clothesCount / size);
     const isLast = clothesCount < page * size + size;
-    const startIndex = isLast ? Math.max(0, clothesCount - size) : page * size;
+    const startIndex = pageIndex * size;
     const items = await this.customersService.getCustomerClothes(id, {
       limit: size,
       skip: startIndex,

--- a/apps/back/src/modules/employees/employees.controller.ts
+++ b/apps/back/src/modules/employees/employees.controller.ts
@@ -12,23 +12,21 @@ import {
 } from '@nestjs/common';
 import { EmployeesService } from './employees.service';
 import {
+  InGetEmployeeDTO,
+  InPatchEmployeeDTO,
+  OutDeleteEmployeeDTO,
+  OutGetEmployeeDTO,
+  OutGetEmployeesDTO,
   OutGetMeDto,
+  ParamDeleteEmployeeDTO,
+  ParamGetEmployeeDTO,
   Permission,
   PhotoFormat,
   QueryGetEmployeesCountDTO,
+  QueryGetEmployeesDTO,
 } from '@seminar/common';
 import { ImagesService } from '../images/images.service';
 import { ImageTokenType } from '../../types/images';
-import {
-  ParamGetEmployeeDTO,
-  OutGetEmployeeDTO,
-  InGetEmployeeDTO,
-  InPatchEmployeeDTO,
-  ParamDeleteEmployeeDTO,
-  OutDeleteEmployeeDTO,
-  QueryGetEmployeesDTO,
-  OutGetEmployeesDTO,
-} from '@seminar/common';
 import { PermissionsService } from '../permissions/permissions.service';
 import { UpdateEmployeeCandidate } from '../../types/employees';
 import { AuthEmployeeContext } from '../auth/auth.employee.context';
@@ -78,10 +76,10 @@ export class EmployeesController {
   ): Promise<OutGetEmployeesDTO> {
     const employeesCount =
       await this._employeesService.getEmployeesCount(filters);
+
+    const pageIndex = Math.floor(employeesCount / size);
     const isLast = employeesCount <= page * size + size;
-    const startIndex = isLast
-      ? Math.max(0, employeesCount - size)
-      : page * size;
+    const startIndex = pageIndex * size;
     const items = await this._employeesService.getEmployees(
       filters,
       size,

--- a/apps/back/src/modules/events/events-migration.service.ts
+++ b/apps/back/src/modules/events/events-migration.service.ts
@@ -1,0 +1,164 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { EventsFilters } from '@seminar/common';
+import { EventsService } from './events.service';
+import { EventLegacyDto } from '../../types/legacy-api/dtos';
+import {
+  Event as PrismaEvent,
+  Location as PrismaEventLocation,
+} from '.prisma/client';
+import { AuthEmployeeContext } from '../auth/auth.employee.context';
+import { LegacyApiService } from '../../providers/legacy-api/legacy-api.service';
+import { EmployeesMigrationService } from '../employees/employees-migration.service';
+
+@Injectable()
+export class EventsMigrationService extends EventsService {
+  @Inject(AuthEmployeeContext)
+  private readonly _authEmployeeContext: AuthEmployeeContext;
+
+  @Inject(LegacyApiService)
+  private readonly _legacyApiService: LegacyApiService;
+
+  @Inject(EmployeesMigrationService)
+  private readonly _employeesMigrationService: EmployeesMigrationService;
+
+  public async syncEvents(filters: EventsFilters): Promise<void> {
+    if (!this._authEmployeeContext.isLegacyAuthenticated) {
+      return;
+    }
+    const events = await this._legacyApiService.request(
+      'GET /events',
+      {},
+      this._authEmployeeContext.employee.legacyToken!,
+    );
+
+    let toCreate: EventLegacyDto[] = [];
+
+    const locationsToCreate: Omit<PrismaEventLocation, 'id'>[] = [];
+
+    const existingLegacyIds: number[] = (
+      await this._prismaService.event.findMany({
+        select: {
+          legacyId: true,
+        },
+      })
+    )
+      .filter((event) => event.legacyId)
+      .map((event) => event.legacyId!);
+
+    events.data = events.data.filter((event) => {
+      if (existingLegacyIds.includes(event.id)) {
+        return false;
+      }
+      const date = new Date(event.date);
+      return !(
+        filters.year &&
+        date.getFullYear() !== filters.year &&
+        filters.month &&
+        date.getMonth() !== filters.month
+      );
+    });
+
+    for (const event of events.data) {
+      const eventToCreate = await this._legacyApiService.request(
+        'GET /events/{event_id}',
+        {
+          parameters: {
+            event_id: event.id,
+          },
+        },
+        this._authEmployeeContext.employee.legacyToken!,
+      );
+
+      locationsToCreate.push({
+        name: eventToCreate.data.location_name,
+        x: eventToCreate.data.location_x,
+        y: eventToCreate.data.location_y,
+      });
+
+      toCreate.push(eventToCreate.data);
+    }
+
+    toCreate = toCreate.filter((event) => event);
+
+    if (!toCreate.length) {
+      console.log('No events to sync');
+      return;
+    }
+
+    await this._employeesMigrationService.syncEmployees();
+
+    await this._prismaService.location.createMany({
+      data: locationsToCreate,
+      skipDuplicates: true,
+    });
+
+    const locations = (
+      await this._prismaService.location.findMany({
+        select: {
+          id: true,
+          name: true,
+          x: true,
+          y: true,
+        },
+      })
+    ).map((location): [string, number] => {
+      return [location.name + location.x + location.y, location.id];
+    });
+
+    const locationsMap = new Map<string, number>(locations);
+    const employees = await this._prismaService.employee.findMany({
+      select: {
+        id: true,
+        legacyId: true,
+      },
+    });
+
+    const employeesMap = new Map<number, number>(
+      employees
+        .filter((employee) => employee.legacyId)
+        .map((employee) => [employee.legacyId!, employee.id]),
+    );
+    console.log(employeesMap);
+    const data = toCreate.map((event): Omit<PrismaEvent, 'id'> => {
+      console.log(
+        `Looking for: ${event.employee_id}`,
+        employeesMap.get(event.employee_id),
+      );
+      const start = new Date(event.date);
+      const end = new Date(start);
+      const hoursToAdd = event.duration / 60;
+      const minutesToAdd = event.duration % 60;
+      const daysToAdd = start.getHours() + hoursToAdd >= 24 ? 1 : 0;
+      end.setDate(start.getDate() + daysToAdd);
+      end.setHours(
+        daysToAdd > 0
+          ? start.getHours() + hoursToAdd - 24
+          : start.getHours() + hoursToAdd,
+      );
+      end.setMinutes(end.getMinutes() + minutesToAdd);
+      end.setSeconds(0);
+      return {
+        locationId: locationsMap.get(
+          event.location_name + event.location_x + event.location_y,
+        )!,
+        title: event.name,
+        maxParticipants: event.max_participants,
+        employeeId: employeesMap.get(event.employee_id)!,
+        start: new Date(event.date),
+        end: end,
+        legacyId: event.id,
+        type: event.type,
+      };
+    });
+
+    await this._prismaService.event.createMany({
+      data,
+      skipDuplicates: true,
+    });
+  }
+
+  async getEventsCount(filters: EventsFilters): Promise<number> {
+    await this.syncEvents(filters);
+    return super.getEventsCount(filters);
+  }
+}

--- a/apps/back/src/modules/events/events.controller.ts
+++ b/apps/back/src/modules/events/events.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  Inject,
+  NotFoundException,
+  Param,
+  Patch,
+  Query,
+} from '@nestjs/common';
+import {
+  GetEventsDTO,
+  GetEventsQuery,
+  IdOf,
+  InUpdateEventDTO,
+  MeetingEvent,
+  Permission,
+} from '@seminar/common';
+import { EventsService } from './events.service';
+import { AuthEmployeeContext } from '../auth/auth.employee.context';
+
+@Controller('events')
+export class EventsController {
+  @Inject(EventsService)
+  private readonly _eventsService: EventsService;
+
+  @Inject(AuthEmployeeContext)
+  private readonly _authEmployeeContext: AuthEmployeeContext;
+
+  @Get()
+  public async getEvents(
+    @Query() query: GetEventsQuery,
+  ): Promise<GetEventsDTO> {
+    const count = await this._eventsService.getEventsCount(query);
+    const events = await this._eventsService.getEvents(query);
+
+    return { count, events };
+  }
+
+  @Get(':id')
+  public async getEventById(
+    @Query('id') id: IdOf<MeetingEvent>,
+  ): Promise<MeetingEvent | null> {
+    return this._eventsService.getEventById(id);
+  }
+
+  @Patch(':id')
+  public async updateEvent(
+    @Param('id') id: IdOf<MeetingEvent>,
+    @Body() data: InUpdateEventDTO,
+  ): Promise<MeetingEvent> {
+    const event = await this._eventsService.getEventById(id);
+    if (!event) {
+      throw new NotFoundException('Event not found');
+    }
+
+    if (
+      this._authEmployeeContext.employee.permission !== Permission.MANAGER &&
+      this._authEmployeeContext.employee.id !== event.employeeId
+    ) {
+      throw new ForbiddenException('You are not allowed to update this event');
+    }
+
+    return (await this._eventsService.updateEvent(id, data))!;
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  public async deleteEvent(@Param('id') id: IdOf<MeetingEvent>): Promise<void> {
+    const event = await this._eventsService.getEventById(id);
+    if (!event) {
+      throw new NotFoundException('Event not found');
+    }
+
+    if (
+      this._authEmployeeContext.employee.permission !== Permission.MANAGER &&
+      this._authEmployeeContext.employee.id !== event.employeeId
+    ) {
+      throw new ForbiddenException('You are not allowed to delete this event');
+    }
+
+    await this._eventsService.deleteEvent(id);
+  }
+}

--- a/apps/back/src/modules/events/events.module.ts
+++ b/apps/back/src/modules/events/events.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../providers';
+import { EventsService as OriginalEventsService } from './events.service';
+import { EventsController } from './events.controller';
+import { AuthModule } from '../auth/auth.module';
+import { EventsMigrationService } from './events-migration.service';
+import { LegacyApiModule } from '../../providers/legacy-api/legacy-api.module';
+import { EmployeesModule } from '../employees/employees.module';
+
+const EventsService = {
+  provide: OriginalEventsService,
+  useClass: EventsMigrationService,
+};
+
+@Module({
+  imports: [PrismaModule, AuthModule, LegacyApiModule, EmployeesModule],
+  controllers: [EventsController],
+  providers: [EventsService],
+})
+export class EventsModule {}

--- a/apps/back/src/modules/events/events.service.ts
+++ b/apps/back/src/modules/events/events.service.ts
@@ -1,0 +1,68 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { PrismaService } from '../../providers';
+import { EventsFilters, IdOf, MeetingEvent } from '@seminar/common';
+import { CreateEventCandidate, UpdateEventCandidate } from '../../types/events';
+
+@Injectable()
+export class EventsService {
+  @Inject(PrismaService)
+  protected readonly _prismaService: PrismaService;
+
+  async getEventsCount(filters: EventsFilters): Promise<number> {
+    const _from = new Date(filters.year, filters.month ?? 0);
+    const _to = new Date(filters.year, (filters.month ?? 11) + 1);
+    return this._prismaService.event.count({
+      where: {
+        start: {
+          gte: _from,
+          lt: _to,
+        },
+      },
+    });
+  }
+
+  async getEvents(filters: EventsFilters): Promise<MeetingEvent[]> {
+    const _from = new Date(filters.year, filters.month ?? 0);
+    const _to = new Date(filters.year, (filters.month ?? 11) + 1);
+    return this._prismaService.event.findMany({
+      where: {
+        start: {
+          gte: _from,
+          lt: _to,
+        },
+      },
+    });
+  }
+
+  async getEventById(id: IdOf<MeetingEvent>): Promise<MeetingEvent | null> {
+    return this._prismaService.event.findUnique({
+      where: { id },
+    });
+  }
+
+  async doesEventExist(id: IdOf<MeetingEvent>): Promise<boolean> {
+    return (await this._prismaService.event.count({ where: { id } })) > 0;
+  }
+
+  async createEvent(data: CreateEventCandidate): Promise<MeetingEvent> {
+    return this._prismaService.event.create({ data });
+  }
+
+  async updateEvent(
+    id: IdOf<MeetingEvent>,
+    data: UpdateEventCandidate,
+  ): Promise<MeetingEvent | null> {
+    if (!(await this.doesEventExist(id))) return null;
+
+    return this._prismaService.event.update({
+      where: { id },
+      data,
+    });
+  }
+
+  async deleteEvent(id: IdOf<MeetingEvent>): Promise<void> {
+    if (!(await this.doesEventExist(id))) return;
+
+    await this._prismaService.event.delete({ where: { id } });
+  }
+}

--- a/apps/back/src/modules/statistics/statistics.service.ts
+++ b/apps/back/src/modules/statistics/statistics.service.ts
@@ -224,7 +224,7 @@ export class StatisticsService {
   public async getEventsCount(timeframe: TimeFrame): Promise<number> {
     return this._prismaService.event.count({
       where: {
-        date: {
+        start: {
           gte: timeframe.start,
           lte: timeframe.end,
         },

--- a/apps/back/src/types/events/candidates.ts
+++ b/apps/back/src/types/events/candidates.ts
@@ -1,0 +1,5 @@
+import { MeetingEvent } from '@seminar/common';
+
+export type UpdateEventCandidate = Partial<Omit<MeetingEvent, 'id'>>;
+
+export type CreateEventCandidate = Omit<MeetingEvent, 'id'>;

--- a/apps/back/src/types/events/index.ts
+++ b/apps/back/src/types/events/index.ts
@@ -1,0 +1,1 @@
+export * from './candidates';

--- a/apps/front/src/api/events/index.ts
+++ b/apps/front/src/api/events/index.ts
@@ -1,0 +1,7 @@
+import { list } from "./list";
+
+const events = {
+  list,
+};
+
+export default events;

--- a/apps/front/src/api/events/list.ts
+++ b/apps/front/src/api/events/list.ts
@@ -1,0 +1,9 @@
+import { GetEventsDTO, GetEventsQuery } from "@seminar/common";
+import { call } from "../call";
+
+export function list(query: GetEventsQuery) {
+  return call<undefined, GetEventsDTO>(
+    "GET",
+    `/events?${new URLSearchParams(query as any)}`,
+  );
+}

--- a/apps/front/src/api/index.ts
+++ b/apps/front/src/api/index.ts
@@ -3,13 +3,15 @@ import { call } from "./call";
 import customers from "./customers";
 import employees from "./employees";
 import statistics from "./statistics";
+import events from "./events";
 
 const api = {
-    call,
-    auth,
-    employees,
-    customers,
-    statistics,
+  call,
+  auth,
+  employees,
+  customers,
+  statistics,
+  events,
 };
 
 export default api;

--- a/apps/front/src/app/events/layout.tsx
+++ b/apps/front/src/app/events/layout.tsx
@@ -1,0 +1,17 @@
+import { MainMenu } from "@/components/menus/main";
+import React from "react";
+
+const containerClassName = "container m-auto py-6 px-2";
+
+export default function EventsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <MainMenu />
+      <div className={containerClassName}>{children}</div>
+    </>
+  );
+}

--- a/apps/front/src/app/events/page.tsx
+++ b/apps/front/src/app/events/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+import React from "react";
+import { Subtitle } from "@/components/text/subtitle";
+import { Card } from "@/components/ui/card";
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import { EventInput } from "@fullcalendar/core";
+import api from "@/api";
+import { MeetingEvent } from "@seminar/common";
+
+export default function Events() {
+  const fetchEvents = async (
+    fetchInfo: { start: Date; end: Date },
+    successCallback: any,
+    failureCallback: any,
+  ): Promise<EventInput[]> => {
+    const response = await api.events.list({
+      month: fetchInfo.start.getMonth() + 1,
+      year: fetchInfo.start.getFullYear(),
+    });
+
+    if (response && response.data) {
+      const events = response.data.events.map(
+        (event: MeetingEvent): EventInput => {
+          return {
+            title: event.title,
+            start: event.start,
+            end: event.end,
+          };
+        },
+      );
+      successCallback(events);
+      return events;
+    } else {
+      failureCallback(response);
+      return [];
+    }
+  };
+
+  return (
+    <main>
+      <Subtitle text="Events" />
+      <Card className={"p-4"}>
+        <FullCalendar
+          plugins={[dayGridPlugin]}
+          initialView="dayGridMonth"
+          events={fetchEvents}
+        />
+      </Card>
+    </main>
+  );
+}

--- a/apps/front/tsconfig.json
+++ b/apps/front/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
+        "target": "ES2021",
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,12 @@
       "workspaces": [
         "apps/*",
         "packages/*"
-      ]
+      ],
+      "dependencies": {
+        "@fullcalendar/core": "^6.1.15",
+        "@fullcalendar/daygrid": "^6.1.15",
+        "@fullcalendar/react": "^6.1.15"
+      }
     },
     "apps/back": {
       "name": "@seminar/back",
@@ -1197,6 +1202,32 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
       "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
       "license": "MIT"
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.15.tgz",
+      "integrity": "sha512-BuX7o6ALpLb84cMw1FCB9/cSgF4JbVO894cjJZ6kP74jzbUZNjtwffwRdA+Id8rrLjT30d/7TrkW90k4zbXB5Q==",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz",
+      "integrity": "sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.15.tgz",
+      "integrity": "sha512-L0b9hybS2J4e7lq6G2CD4nqriyLEqOH1tE8iI6JQjAMTVh5JicOo5Mqw+fhU5bJ7hLfMw2K3fksxX3Ul1ssw5w==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/@heroicons/react": {
       "version": "2.1.5",
@@ -12101,6 +12132,15 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -18,5 +18,10 @@
     "front:dev": "npm run dev --workspace=@seminar/front",
     "front:start": "npm run start --workspace=@seminar/front",
     "postinstall": "npm run build --workspace=@seminar/common"
+  },
+  "dependencies": {
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15"
   }
 }

--- a/packages/common/src/dtos/events/get-events.dto.ts
+++ b/packages/common/src/dtos/events/get-events.dto.ts
@@ -1,0 +1,22 @@
+import { IsInt, IsOptional, Max, Min } from "class-validator";
+import { MeetingEvent } from "../../types";
+import { Type } from "class-transformer";
+
+export class GetEventsQuery {
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(11)
+  @Type(() => Number)
+  month?: number;
+
+  @IsInt()
+  @Min(1582)
+  @Type(() => Number)
+  year: number;
+}
+
+export type GetEventsDTO = {
+  count: number;
+  events: MeetingEvent[];
+};

--- a/packages/common/src/dtos/events/index.ts
+++ b/packages/common/src/dtos/events/index.ts
@@ -1,0 +1,2 @@
+export * from "./get-events.dto";
+export * from "./patch-event.dto";

--- a/packages/common/src/dtos/events/patch-event.dto.ts
+++ b/packages/common/src/dtos/events/patch-event.dto.ts
@@ -1,0 +1,44 @@
+import { MeetingEvent } from "../../types";
+import {
+  IsDate,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from "class-validator";
+import { Type } from "class-transformer";
+
+export class InUpdateEventDTO {
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  title?: string;
+
+  @IsDate()
+  @IsOptional()
+  @Type(() => Date)
+  start?: Date;
+
+  @IsDate()
+  @IsOptional()
+  @Type(() => Date)
+  end?: Date;
+
+  @IsInt()
+  @IsOptional()
+  maxParticipants?: number;
+
+  @IsInt()
+  @IsOptional()
+  locationId?: number;
+
+  @IsString()
+  @IsOptional()
+  type?: string;
+
+  @IsInt()
+  @IsOptional()
+  employeeId?: number;
+}
+
+export type OutUpdateEventDTO = MeetingEvent;

--- a/packages/common/src/dtos/index.ts
+++ b/packages/common/src/dtos/index.ts
@@ -3,3 +3,4 @@ export * from "./customers";
 export * from "./employees";
 export * from "./statistics";
 export * from "./images";
+export * from "./events";

--- a/packages/common/src/types/event.type.ts
+++ b/packages/common/src/types/event.type.ts
@@ -14,9 +14,15 @@ export type MeetingEvent = {
   id: number;
   legacyId: number | null;
   title: string;
-  date: Date;
+  start: Date;
+  end: Date;
   maxParticipants: number;
   locationId: IdOf<EventLocation>;
   type: string;
   employeeId: IdOf<Employee>;
+};
+
+export type EventsFilters = {
+  month?: number;
+  year: number;
 };


### PR DESCRIPTION
I added the event page with its calendar. The backend for events has also been done with the migration.

> [!NOTE]
> The legacy api provided a way to know which customers attended which events. The back-end was built with the same idea when designing the data models. But since this data is not accessible with the current state of the mock-up given by the client, I took the liberty of not migrating this data for now.
